### PR TITLE
Various fixes

### DIFF
--- a/preferences.json
+++ b/preferences.json
@@ -36,5 +36,23 @@
     "type": "checkbox",
     "label": "Show only AI renaming debug logs (requires debug enabled)",
     "defaultValue": true
+  },
+  {
+    "property": "extensions.downloads.stable_focus_mode",
+    "type": "checkbox",
+    "label": "Prevent focus switching during multiple downloads",
+    "defaultValue": true
+  },
+  {
+    "property": "extensions.downloads.progress_update_throttle_ms",
+    "type": "number",
+    "label": "Throttle delay for in-progress download updates (ms)",
+    "defaultValue": 500
+  },
+  {
+    "property": "extensions.downloads.show_old_downloads_hours",
+    "type": "number",
+    "label": "Show old completed downloads on startup (hours)",
+    "defaultValue": 2
   }
 ] 


### PR DESCRIPTION
- Fixed handling multiple downloads at once without having the focus switch on every update.
- Fixed canceling download and redownloading hiding all the pods. (if that was the issue you were talking about)
- Fixed canceling a download sometimes updating the download history list and making the whole list appear.
- Added smart resume of previously canceled downloads. (if the user cancels a download and clicks on the download button again, it won't create a new pod but replace the previously canceled one)
- Added CSS detection to disable the script if no CSS is present.