### PR TITLE
Update to only show on Zen.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -17,5 +17,6 @@
     "Tidy Pack"
   ],
   "createdAt": "2025-05-24",
-  "updatedAt": "2025-06-05"
+  "updatedAt": "2025-06-05",
+  "fork": ["zen"]
 }


### PR DESCRIPTION
@Anoms12 Sine will be adding cross-browser support soon, and as such, I am adding a property to only show mods when they are compatible with the user's browser. That's what this pr does.